### PR TITLE
PKCS#11 fixes

### DIFF
--- a/create-csr
+++ b/create-csr
@@ -151,7 +151,7 @@ openssl rsa \
 
 if [ -z "$ENABLE_ENGINE" ] && [ -z "$CSR_KEY" ]; then
     chmod 0400 "certs/$CSR_TYPE/$SAFE_NAME/$SAFE_NAME.key"
-    ln -s "$SAFE_NAME".key "certs/$CSR_TYPE/$SAFE_NAME/ssh/$SAFE_NAME.ssh"
+    ln -s ./"$SAFE_NAME".key "certs/$CSR_TYPE/$SAFE_NAME/ssh/$SAFE_NAME.ssh"
     openssl rsa -in "certs/$CSR_TYPE/$SAFE_NAME/$SAFE_NAME.key" \
         -pubout -out "certs/$CSR_TYPE/$SAFE_NAME/$SAFE_NAME.pub"
 fi

--- a/create-csr
+++ b/create-csr
@@ -104,7 +104,7 @@ if [[ -z "$CSR_KEY" ]]; then
     read -r ENABLE_ENGINE
     if [ "${ENABLE_ENGINE}" == "y" ] || [ "${ENABLE_ENGINE}" == "Y" ]; then
         ENABLE_ENGINE=1
-        init_slot 9a "certs/$CSR_TYPE/$SAFE_NAME/$SAFE_NAME.pub"
+        init_slot 9a "certs/$CSR_TYPE/$SAFE_NAME/$SAFE_NAME.pub" "pkcs11:object=PIV%20AUTH%20key"
     else
         ENABLE_ENGINE=
         if [ ! -f "certs/$CSR_TYPE/$SAFE_NAME/$SAFE_NAME.key" ]; then

--- a/create-root-ca
+++ b/create-root-ca
@@ -59,7 +59,6 @@ CA_CERT_CN=`ask "$INPUT Common Name for CA certificate [${CA_CERT_CN}]: " CA_ROO
 
 if [[ -n $CA_ENABLE_ENGINE ]]; then
     init_engine
-    init_slot 9c "${CA_DIR}/ca/ca.pub" "pkcs11:object=SIGN%20key"
     # Slot 9c requires PIN entry on every operation.
     # No need to ask for the PIN for re-use.
     echo -e -n "$INPUT Enter PIN for signing root CA key: " >&2
@@ -69,6 +68,7 @@ if [[ -n $CA_ENABLE_ENGINE ]]; then
         echo -e "$ERR Passphrase is too short, please use at least 4 characters!" >&2
         exit 1
     fi
+    CA_PASS="$PASS1" init_slot 9c "${CA_DIR}/ca/ca.pub" "pkcs11:object=SIGN%20key"
 else
     echo >&2
     PASS1=`ask -s "$INPUT Enter passphrase for encrypting root CA key: " CA_ROOT_PASS_DEFAULT "${ROOT_PASS:-""}"`

--- a/create-root-ca
+++ b/create-root-ca
@@ -59,7 +59,7 @@ CA_CERT_CN=`ask "$INPUT Common Name for CA certificate [${CA_CERT_CN}]: " CA_ROO
 
 if [[ -n $CA_ENABLE_ENGINE ]]; then
     init_engine
-    init_slot 9c "${CA_DIR}/ca/ca.pub"
+    init_slot 9c "${CA_DIR}/ca/ca.pub" "pkcs11:object=SIGN%20key"
     # Slot 9c requires PIN entry on every operation.
     # No need to ask for the PIN for re-use.
     echo -e -n "$INPUT Enter PIN for signing root CA key: " >&2

--- a/create-server
+++ b/create-server
@@ -106,7 +106,7 @@ if [ "${SURE}" != "y" ] && [ "${SURE}" != "Y" ]; then
     ENABLE_ENGINE=
 else
     ENABLE_ENGINE=1
-    init_slot 9a "certs/server/$SAFE_NAME/$SAFE_NAME.pub"
+    init_slot 9a "certs/server/$SAFE_NAME/$SAFE_NAME.pub" "pkcs11:object=PIV%20AUTH%20key"
 fi
 
 echo -e "$NOTE Creating the server key and csr" >&2

--- a/create-signing-ca
+++ b/create-signing-ca
@@ -109,7 +109,7 @@ if [[ -n $CA_ENABLE_ENGINE ]]; then
         fi
     done
     init_engine
-    init_slot 9c "${CA_DIR}/ca/ca.pub"
+    init_slot 9c "${CA_DIR}/ca/ca.pub" "pkcs11:object=SIGN%20key"
     echo -e -n "$INPUT Enter PIN for signing sub-CA key: " >&2
     read -r -s PASS1
     echo >&2

--- a/functions
+++ b/functions
@@ -340,7 +340,6 @@ function extract_crt(){
 function init_engine(){
     echo -e "$NOTE THIS WILL RESET YOUR YUBIKEY USING YKMAN" >&2
     echo -e "$NOTE Run 'ykman piv reset' on your own to set PIN/PUK/management keys properly." >&2
-    echo -e -n "$INPUT Do you wish to reset your device? [y/N]: " >&2
     local SURE=`ask "$INPUT Do you wish to reset your device? [y/N]: " CA_INIT_ENGINE_SURE ""`
     if [ "${SURE}" == "y" ] || [ "${SURE}" == "Y" ]; then
         ykman piv reset

--- a/functions
+++ b/functions
@@ -269,19 +269,31 @@ function generate_key(){
 function extract_pubkey(){
     local CRTPATH=$1
     local PUBPATH=$2
-    openssl x509 -in $CRTPATH -pubkey -noout -passin env:CA_PASS > $PUBPATH
+    local PASS_ARG="-passin env:CA_PASS"
+    if [ -z "${CA_PASS-}" ]; then
+      PASS_ARG=
+    fi
+    openssl x509 -in $CRTPATH -pubkey -noout $PASS_ARG > $PUBPATH
 }
 function generate_pubkey(){
     local KEYPATH=$1
     local PUBPATH=$2
-    openssl rsa -in $KEYPATH -pubout -out $PUBPATH -passin env:CA_PASS
+    local PASS_ARG="-passin env:CA_PASS"
+    if [ -z "${CA_PASS-}" ]; then
+      PASS_ARG=
+    fi
+    openssl rsa -in $KEYPATH -pubout -out $PUBPATH $PASS_ARG
 }
 function generate_pubkey_pkcs11(){
     local KEYPATH=$1
     local PUBPATH=$2
-    echo -e "$NOTE CA key should already exist via pkcs11 engine." >&2
+    local PASS_ARG="-passin env:CA_PASS"
+    if [ -z "${CA_PASS-}" ]; then
+      PASS_ARG=
+    fi
+    echo -e "$NOTE key should already exist via pkcs11 engine." >&2
     openssl rsa -engine pkcs11 -inform engine \
-                -in $KEYPATH -pubout -out $PUBPATH -passin env:CA_PASS
+                -in $KEYPATH -pubout -out $PUBPATH $PASS_ARG
 }
 
 function generate_pubkey_ssh(){


### PR DESCRIPTION
Hi,

I tried out easy-ca with a yubikey in PIV mode, but ran in to a few issues. Most fixes are pkcs11-specific, but the create-csr fix is of a more generic nature. Also the pubkey-functions is touched for both the pkcs11- and non-pkcs11 code path. For that patch I only needed to fix generate_pubkey_pkcs11, but thought I would do the rest as well for consistency. I can trim that patch down to only alter generate_pubkey_pkcs11 if that is preferred.

Cheers,
/Jonas