### PR TITLE
Supports Creating Code Signing Certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # testing CA
 testCA/
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A suite of bash scripts for automating very basic OpenSSL Certificate Authority 
 * Creating Intermediate Signing CAs
 * Creating Server certificates
 * Creating Client certificates
+* Creating Code Signing certificates
 * Revoking certificates and maintaining CRLs
 * Creating CSRs
 * Managing SSH keys
@@ -22,7 +23,7 @@ A suite of bash scripts for automating very basic OpenSSL Certificate Authority 
 | Name              | Description                                                       |
 | ----------------- | ----------------------------------------------------------------- |
 | create-client     | Create a client certificate                                       |
-| create-codesign   | Create a code signing certificate                                       |
+| create-codesign   | Create a code signing certificate                                 |
 | create-root-ca    | Create a root signing CA                                          |
 | create-server     | Create a server certificate                                       |
 | create-signing-ca | Create an intermediate signing CA inside a root CA                |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A suite of bash scripts for automating very basic OpenSSL Certificate Authority 
 | Name              | Description                                                       |
 | ----------------- | ----------------------------------------------------------------- |
 | create-client     | Create a client certificate                                       |
+| create-codesign   | Create a code signing certificate                                       |
 | create-root-ca    | Create a root signing CA                                          |
 | create-server     | Create a server certificate                                       |
 | create-signing-ca | Create an intermediate signing CA inside a root CA                |
@@ -34,12 +35,12 @@ A suite of bash scripts for automating very basic OpenSSL Certificate Authority 
 
 #### Important files:
 
-| Path                    | Description                              |
-| ----------------------- | ---------------------------------------- |
-| bin/                    | Script directory                         |
-| ca/ca.crt               | CA certificate                           |
-| ca/chain.pem            | CA chain certificate                     |
-| certs/(client\|server)/ | Parent directory for signed certificates |
+| Path                              | Description                              |
+| --------------------------------- | ---------------------------------------- |
+| bin/                              | Script directory                         |
+| ca/ca.crt                         | CA certificate                           |
+| ca/chain.pem                      | CA chain certificate                     |
+| certs/(client\|server\|codesign)/ | Parent directory for signed certificates |
 
 ### Create a new Root CA
 
@@ -107,14 +108,33 @@ Running **create-client** from within any CA installation will issue a new clien
 $CA_DIR/bin/create-client -c user@domain.com
 ```
 
-**create-client** will prompt for basic DN configuration, using the CA configuration as defaults. After the script is completed, the client certificate, key, and CSR are available for review in the directory *$CA_DIR/certs/clients/user-domain-com/*:
+**create-client** will prompt for basic DN configuration, using the CA configuration as defaults. After the script is completed, the client certificate, key, CSR and p12 files are available for review in the directory *$CA_DIR/certs/clients/user-domain-com/*:
 
 ```
 $CA_DIR/certs/clients/user-domain-com/user-domain-com.crt
 $CA_DIR/certs/clients/user-domain-com/user-domain-com.key
+$CA_DIR/certs/clients/user-domain-com/user-domain-com.p12
 $CA_DIR/certs/clients/user-domain-com/user-domain-com.pub
 $CA_DIR/certs/clients/user-domain-com/user-domain-com.ssh.pub
 $CA_DIR/certs/clients/user-domain-com/user-domain-com.csr
+```
+
+### Issue a Code Signing Certificate
+
+Running **create-codesign** from within any CA installation will issue a new code signing certificate:
+
+```
+$CA_DIR/bin/create-codesign -c name
+```
+
+**create-cocesign** will prompt for basic DN configuration, using the CA configuration as defaults. After the script is completed, the code signing certificate, key, CSR and p12 files are available for review in the directory *$CA_DIR/certs/codesign/name/*:
+
+```
+$CA_DIR/certs/codesign/name/name.crt
+$CA_DIR/certs/codesign/name/name.key
+$CA_DIR/certs/codesign/name/name.p12
+$CA_DIR/certs/codesign/name/name.pub
+$CA_DIR/certs/codesign/name/name.csr
 ```
 
 ### Revoke a Certificate

--- a/create-client
+++ b/create-client
@@ -187,6 +187,14 @@ echo -e "$NOTE Verifying trusted chain" >&2
 
 openssl verify -CAfile ca/chain.pem "certs/clients/$SAFE_NAME/$SAFE_NAME.crt"
 
+echo -e "$NOTE Exporting to a p12 file" >&2
+
+openssl pkcs12 -export \
+    -in certs/clients/$SAFE_NAME/$SAFE_NAME.crt \
+    -inkey certs/clients/$SAFE_NAME/$SAFE_NAME.key \
+    -certfile ca/ca.crt \
+    -out certs/clients/$SAFE_NAME/$SAFE_NAME.p12
+
 popd > /dev/null
 
 unset CA_PASS

--- a/create-codesign
+++ b/create-codesign
@@ -18,11 +18,11 @@ source "${BIN_DIR}/functions"
 source "${BIN_DIR}/defaults.conf"
 
 usage() {
-    echo "Usage: $0 -c CLIENT_NAME"
-    echo "Issues a code signing certificate for CLIENT_NAME"
+    echo "Usage: $0 -c CERT_NAME"
+    echo "Issues a code signing certificate named CERT_NAME"
     echo
     echo "Options:"
-    echo "    -c CLIENT_NAME  Client name (commonName) for the new cert"
+    echo "    -c CERT_NAME  Certificate name (commonName) for the new cert"
     echo
 }
 
@@ -31,11 +31,11 @@ if [ ! -f ca/ca.crt ]; then
     exit 2
 fi
 
-CLIENT_NAME=
+CERT_NAME=
 
 while getopts c:h FLAG; do
     case $FLAG in
-        c) CLIENT_NAME=${OPTARG} ;;
+        c) CERT_NAME=${OPTARG} ;;
         h) echo -e -n "$SUCC " && usage && exit 0 ;;
         *) echo -e -n "$ERR " && usage && exit 2 ;;
     esac
@@ -43,18 +43,18 @@ done
 
 if [ $OPTIND -le $# ]; then
     echo -e -n "$ERR " && usage && exit 2
-elif [ "${CLIENT_NAME}" = "" ]; then
+elif [ "${CERT_NAME}" = "" ]; then
     echo -e -n "$ERR " && usage && exit 1
 fi
 
-SAFE_NAME=$(echo "${CLIENT_NAME}" | sed 's/\*/star/g' | sed 's/[^A-Za-z0-9-]/-/g')
+SAFE_NAME=$(echo "${CERT_NAME}" | sed 's/\*/star/g' | sed 's/[^A-Za-z0-9-]/-/g')
 
-echo -e "$NOTE Creating new code signing certificate for '$CLIENT_NAME'" >&2
+echo -e "$NOTE Creating new code signing certificate named '$CERT_NAME'" >&2
 
 pushd "${BIN_DIR}/.." > /dev/null
 
 if [ -d "certs/codesign/$SAFE_NAME" ]; then
-    echo -e "$ERR Configuration already exists for '$CLIENT_NAME' ($SAFE_NAME), exiting." >&2
+    echo -e "$ERR Configuration already exists for '$CERT_NAME' ($SAFE_NAME), exiting." >&2
     exit 1
 fi
 
@@ -81,7 +81,7 @@ trap 'rm -Rf "certs/codesign/$SAFE_NAME"' 0
 mkdir -p "certs/codesign/$SAFE_NAME"
 
 # Generate the code signing cert openssl config
-export CA_USERNAME="${CLIENT_NAME}"
+export CA_USERNAME="${CERT_NAME}"
 export CA_CERT_MAIL=""
 ask_client_cert_questions
 export SAN="email:$CA_CERT_MAIL"
@@ -190,4 +190,4 @@ unset CA_PASS
 
 trap 0
 
-echo -e "$SUCC Code Signing certificate for '${CLIENT_NAME}' created."
+echo -e "$SUCC Code Signing certificate named '${CERT_NAME}' created."

--- a/create-codesign
+++ b/create-codesign
@@ -190,4 +190,4 @@ unset CA_PASS
 
 trap 0
 
-echo -e "$SUCC Client certificate for '${CLIENT_NAME}' created."
+echo -e "$SUCC Code Signing certificate for '${CLIENT_NAME}' created."

--- a/create-codesign
+++ b/create-codesign
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Derek Moore <derek.moore@gmail.com>
+# Christian Göttsche <cgzones@googlemail.com>
+# Tom Bereknyei <tomberek@gmail.com>
+
+set -eu
+set -o pipefail
+
+umask 0077
+
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${BIN_DIR}/functions"
+source "${BIN_DIR}/defaults.conf"
+
+usage() {
+    echo "Usage: $0 -c CLIENT_NAME"
+    echo "Issues a code signing certificate for CLIENT_NAME"
+    echo
+    echo "Options:"
+    echo "    -c CLIENT_NAME  Client name (commonName) for the new cert"
+    echo
+}
+
+if [ ! -f ca/ca.crt ]; then
+    echo -e "$ERR Must be run inside a CA directory!"
+    exit 2
+fi
+
+CLIENT_NAME=
+
+while getopts c:h FLAG; do
+    case $FLAG in
+        c) CLIENT_NAME=${OPTARG} ;;
+        h) echo -e -n "$SUCC " && usage && exit 0 ;;
+        *) echo -e -n "$ERR " && usage && exit 2 ;;
+    esac
+done
+
+if [ $OPTIND -le $# ]; then
+    echo -e -n "$ERR " && usage && exit 2
+elif [ "${CLIENT_NAME}" = "" ]; then
+    echo -e -n "$ERR " && usage && exit 1
+fi
+
+SAFE_NAME=$(echo "${CLIENT_NAME}" | sed 's/\*/star/g' | sed 's/[^A-Za-z0-9-]/-/g')
+
+echo -e "$NOTE Creating new code signing certificate for '$CLIENT_NAME'" >&2
+
+pushd "${BIN_DIR}/.." > /dev/null
+
+if [ -d "certs/codesign/$SAFE_NAME" ]; then
+    echo -e "$ERR Configuration already exists for '$CLIENT_NAME' ($SAFE_NAME), exiting." >&2
+    exit 1
+fi
+
+
+echo
+if [ -n "$CA_ENABLE_ENGINE" ]; then
+    echo -e "$NOTE Your CA key is on PKCS11 device, enter PIN." >&2
+fi
+PASS=`ask -s "$INPUT Enter passphrase for signing CA key: " CA_SIGN_PASS_DEFAULT "${SIGN_PASS:-""}"`
+echo >&2
+export CA_PASS="${PASS}"
+
+openssl_engine_cmd='
+    -engine pkcs11 
+    -inform engine
+    -in pkcs11:object=SIGN%20key'
+openssl rsa \
+            ${CA_ENABLE_ENGINE:+$openssl_engine_cmd} \
+            $( [ -z $CA_ENABLE_ENGINE ] && echo "-check -in ca/private/ca.key") \
+            -noout \
+            -passin env:CA_PASS
+
+trap 'rm -Rf "certs/codesign/$SAFE_NAME"' 0
+mkdir -p "certs/codesign/$SAFE_NAME"
+
+# Generate the code signing cert openssl config
+export CA_USERNAME="${CLIENT_NAME}"
+export CA_CERT_MAIL=""
+ask_client_cert_questions
+export SAN="email:$CA_CERT_MAIL"
+template "${BIN_DIR}/templates/codesign.tpl" "certs/codesign/$SAFE_NAME/$SAFE_NAME.conf"
+
+SURE=`ask "$INPUT Create csr on pkcs11 device? (key must be in \"PIV AUTH key\" or 9a) [y/N]: " CA_USE_PKCS11 "N"`
+if [ "${SURE}" != "y" ] && [ "${SURE}" != "Y" ]; then
+    ENABLE_ENGINE=
+else
+    echo -e -n "$INPUT Enter PIN for PIV key: " >&2
+    read -r -s PASS
+    echo >&2
+    export PIV_PASS="${PASS}"
+    ENABLE_ENGINE=1
+    CA_PASS=$PIV_PASS init_slot 9a "certs/codesign/$SAFE_NAME/$SAFE_NAME.pub" "pkcs11:object=PIV%20AUTH%20key"
+fi
+
+echo -e "$NOTE Creating the code signing key and csr" >&2
+
+# Create the code signing key and csr
+openssl_engine_cmd='
+    -engine pkcs11 
+    -keyform engine
+    -key pkcs11:object=PIV%20AUTH%20key
+    -passin env:PIV_PASS'
+openssl req -new -batch \
+            ${ENABLE_ENGINE:+$openssl_engine_cmd} \
+            -config "certs/codesign/$SAFE_NAME/$SAFE_NAME.conf" \
+            -out "certs/codesign/$SAFE_NAME/$SAFE_NAME.csr" \
+            $( [ -z $ENABLE_ENGINE ] && echo "
+            -nodes
+            -keyout certs/codesign/$SAFE_NAME/$SAFE_NAME.key")
+
+openssl_engine_cmd='
+    -engine pkcs11 
+    -inform engine
+    -in pkcs11:object=PIV%20AUTH%20key
+    -passin env:PIV_PASS'
+openssl rsa \
+            ${ENABLE_ENGINE:+$openssl_engine_cmd} \
+            $( [ -z $ENABLE_ENGINE ] && echo "-check -in certs/codesign/$SAFE_NAME/$SAFE_NAME.key") \
+            -noout
+
+if [ -z "$ENABLE_ENGINE" ]; then
+    chmod 0400 "certs/codesign/$SAFE_NAME/$SAFE_NAME.key"
+    openssl rsa -in "certs/codesign/$SAFE_NAME/$SAFE_NAME.key" \
+        -pubout -out "certs/codesign/$SAFE_NAME/$SAFE_NAME.pub"
+fi
+
+echo -e "$NOTE Creating the code signing certificate" >&2
+
+# Create the code signing certificate
+openssl_engine_cmd="\
+    -engine pkcs11 \
+    -keyform engine \
+    -keyfile pkcs11:object=SIGN%20key"
+openssl ca -batch -notext \
+           ${CA_ENABLE_ENGINE:+$openssl_engine_cmd} \
+           -config ca/ca.conf \
+           -in "certs/codesign/$SAFE_NAME/$SAFE_NAME.csr" \
+           -out "certs/codesign/$SAFE_NAME/$SAFE_NAME.crt" \
+           -extensions codesign_ext \
+           -passin env:CA_PASS
+
+if [[ -n "$ENABLE_ENGINE" ]]; then
+    replace_crt 9a certs/codesign/"$SAFE_NAME"/"$SAFE_NAME".crt
+fi
+
+echo -e "$NOTE Verifying certificate/key pair" >&2
+
+openssl_engine_cmd="\
+    -engine pkcs11 \
+    -inform engine \
+    -in pkcs11:object=PIV%20AUTH%20key \
+    -passin env:PIV_PASS"
+key_mod=$(openssl rsa \
+    ${ENABLE_ENGINE:+$openssl_engine_cmd} -noout -modulus \
+    $( [ -z $ENABLE_ENGINE ] && echo "-in certs/codesign/$SAFE_NAME/$SAFE_NAME.key")
+)
+
+cert_mod=$(openssl x509 -noout -modulus -in "certs/codesign/$SAFE_NAME/$SAFE_NAME.crt")
+
+if [ ! "$key_mod" = "$cert_mod" ];then
+    echo -e "$ERR Certificate/Key pair invalid:"
+    echo -e "$ERR     <>$cert_mod<>"
+    echo -e "$ERR     <>$key_mod<>"
+    echo
+    exit 2
+fi
+
+echo -e "$NOTE Verifying trusted chain" >&2
+
+openssl verify -CAfile ca/chain.pem "certs/codesign/$SAFE_NAME/$SAFE_NAME.crt"
+
+echo -e "$NOTE Exporting to a p12 file" >&2
+
+openssl pkcs12 -export \
+    -in certs/codesign/$SAFE_NAME/$SAFE_NAME.crt \
+    -inkey certs/codesign/$SAFE_NAME/$SAFE_NAME.key \
+    -certfile ca/ca.crt \
+    -out certs/codesign/$SAFE_NAME/$SAFE_NAME.p12
+
+popd > /dev/null
+
+unset CA_PASS
+
+trap 0
+
+echo -e "$SUCC Client certificate for '${CLIENT_NAME}' created."

--- a/functions
+++ b/functions
@@ -13,6 +13,7 @@ create-signing-ca
 create-server
 create-client
 create-csr
+create-codesign
 sign-csr
 sign-ssh
 revoke-cert
@@ -28,6 +29,7 @@ export TEMPLATES_ROOT="
 clients.tpl
 server.tpl
 signing.tpl
+codesign.tpl
 root_index.tpl
 sign_index.tpl
 "
@@ -37,6 +39,7 @@ create-signing-ca
 create-server
 create-client
 create-csr
+create-codesign
 sign-csr
 sign-ssh
 revoke-cert
@@ -53,6 +56,7 @@ clients.tpl
 server.tpl
 sign_index.tpl
 signing.tpl
+codesign.tpl
 "
 
 # Output highlighting
@@ -119,6 +123,7 @@ init_ca_home() {
     mkdir certs
     mkdir certs/clients
     mkdir certs/server
+    mkdir certs/codesign
 
     # Create empty databases
     touch ca/db/certificate.db

--- a/show-status
+++ b/show-status
@@ -188,6 +188,7 @@ if [ $certs -gt 0 ]; then
             server_cert=$(echo "$txt" | grep -c 'TLS Web Server Authentication') || true
             sign_cert=$(echo "$txt" | grep -c 'Certificate Sign') || true
             client_cert=$(echo "$txt" | grep -c 'TLS Web Client Authentication') || true
+            code_sign=$(echo "$txt" | grep -c 'Code Signing') || true
             valid_since=$(echo "$txt" | grep 'Not Before:' | cut -d ':' -f2- | sed -e 's/^[[:space:]]*//')
             valid_until=$(echo "$txt" | grep 'Not After :' | cut -d ':' -f2- | sed -e 's/^[[:space:]]*//')
             bits=$(echo "$txt" | grep 'Public-Key:' | cut -d ':' -f2 | tr -d "()")
@@ -200,6 +201,13 @@ if [ $certs -gt 0 ]; then
                 san=""
             elif [ "$client_cert" -ge 1 ]; then
                 type="client"
+                if [ $(echo "$txt" | grep -c 'email:') -eq 0 ]; then
+                    san="                SAN:            no email address found\n"
+                else
+                    san="                SAN:            $(echo "$txt" | grep 'email:' | sed -e 's/^[[:space:]]*//')\n"
+                fi
+            elif [ "$code_sign" -ge 1 ]; then
+                type="code signing"
                 if [ $(echo "$txt" | grep -c 'email:') -eq 0 ]; then
                     san="                SAN:            no email address found\n"
                 else

--- a/templates/codesign.tpl
+++ b/templates/codesign.tpl
@@ -1,7 +1,6 @@
 [ req ]
 default_bits            = {{CA_KEY_LENGTH_ENDCRT}} # RSA key size
-#default_days            = 730                      # How long to certify for
-default_days            = 3652                     # How long to certify for
+default_days            = 730                      # How long to certify for
 encrypt_key             = no                       # Protect private key
 default_md              = sha256                   # MD to use
 utf8                    = yes                      # Input is UTF-8

--- a/templates/codesign.tpl
+++ b/templates/codesign.tpl
@@ -6,11 +6,11 @@ default_md              = sha256                   # MD to use
 utf8                    = yes                      # Input is UTF-8
 string_mask             = utf8only                 # Emit UTF-8 strings
 prompt                  = yes                      # Prompt for DN
-distinguished_name      = client_dn                # DN template
+distinguished_name      = codesign_dn              # DN template
 # extensions
 #req_extensions          = codesign_reqext          # Desired extensions
 
-[ client_dn ]
+[ codesign_dn ]
 countryName                     = "1. Country Name (2 letters) "
 countryName_max                 = 2
 countryName_default             = {{CA_CERT_C}}

--- a/templates/codesign.tpl
+++ b/templates/codesign.tpl
@@ -1,0 +1,35 @@
+[ req ]
+default_bits            = {{CA_KEY_LENGTH_ENDCRT}} # RSA key size
+#default_days            = 730                      # How long to certify for
+default_days            = 3652                     # How long to certify for
+encrypt_key             = no                       # Protect private key
+default_md              = sha256                   # MD to use
+utf8                    = yes                      # Input is UTF-8
+string_mask             = utf8only                 # Emit UTF-8 strings
+prompt                  = yes                      # Prompt for DN
+distinguished_name      = client_dn                # DN template
+# extensions
+#req_extensions          = codesign_reqext          # Desired extensions
+
+[ client_dn ]
+countryName                     = "1. Country Name (2 letters) "
+countryName_max                 = 2
+countryName_default             = {{CA_CERT_C}}
+stateOrProvinceName             = "2. State or Province Name   "
+stateOrProvinceName_default     = {{CA_CERT_ST}}
+localityName                    = "3. Locality Name            "
+localityName_default            = {{CA_CERT_L}}
+organizationName                = "4. Organization Name        "
+organizationName_default        = {{CA_CERT_O}}
+organizationalUnitName          = "5. Organizational Unit Name "
+organizationalUnitName_default  = {{CA_CERT_OU}}
+commonName                      = "6. Common Name              "
+commonName_max                  = 64
+commonName_default              = {{CA_USERNAME}}
+emailAddress                    = "7. Email Address (name@fqdn)"
+emailAddress_max                = 40
+emailAddress_default            = {{CA_CERT_MAIL}}
+
+#[ codesign_reqext ]
+#keyUsage                = digitalSignature
+#extendedKeyUsage        = codeSigning

--- a/templates/root.tpl
+++ b/templates/root.tpl
@@ -117,6 +117,10 @@ authorityInfoAccess     = @issuer_info
 crlDistributionPoints   = @crl_info
 subjectAltName          = $ENV::SAN
 
+[ codesign_ext ]
+keyUsage                = digitalSignature
+extendedKeyUsage        = codeSigning
+
 [ crl_ext ]
 authorityKeyIdentifier  = keyid:always
 authorityInfoAccess     = @issuer_info

--- a/templates/signing.tpl
+++ b/templates/signing.tpl
@@ -101,6 +101,10 @@ authorityInfoAccess     = @issuer_info
 crlDistributionPoints   = @crl_info
 subjectAltName          = $ENV::SAN
 
+[ codesign_ext ]
+keyUsage                = digitalSignature
+extendedKeyUsage        = codeSigning
+
 [ crl_ext ]
 authorityKeyIdentifier  = keyid:always
 authorityInfoAccess     = @issuer_info


### PR DESCRIPTION
Changes

1. Begins to support creating a code signing certificate with which you can digitally sign a code like Excel macro (or VBA).
2. Includes a `.p12` (PKCS#12) file in the output of `create-client` and `create-codesign` for the sake of convenience.  